### PR TITLE
run "docker login" only if success

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ sudo: required
 services:
   - docker
 
-# login on docker hub
-before_install:
-  - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
-
 # build this code into a docker image
 install:
   - docker build -t $DOCKER_REPO:$TRAVIS_BRANCH .
@@ -22,6 +18,7 @@ script:
 
 # if tests passes, push the docker image
 after_success:
+  - docker login -u "$DOCKER_USER" -p "$DOCKER_PASSWORD"
   - docker push $DOCKER_REPO:$TRAVIS_BRANCH
 
 # notify slack about it


### PR DESCRIPTION
it's not necessary to run "docker login" when the build fail, because of course it's will not be send to the hub if that happen
