### PR TITLE
Rename users seeder class name

### DIFF
--- a/app/Domains/Users/Database/Seeders/UsersSeeder.php
+++ b/app/Domains/Users/Database/Seeders/UsersSeeder.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Seeder;
 /**
  * Class UsersSeeders.
  */
-class UserSeeder extends Seeder
+class UsersSeeder extends Seeder
 {
     /**
      * @todo improve users seeders


### PR DESCRIPTION
There was a bug when seeding the users table, the users seeder class was renamed to fix that.
